### PR TITLE
The light client 2-phase interactive verification protocol

### DIFF
--- a/contracts/bridge/contracts/BasicInboundChannel.sol
+++ b/contracts/bridge/contracts/BasicInboundChannel.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@darwinia/contracts-utils/contracts/SafeMath.sol";
+import "./interfaces/ILightClientBridge.sol";
+
+contract BasicInboundChannel {
+    uint256 public constant MAX_GAS_PER_MESSAGE = 100000;
+
+    uint64 public nonce;
+
+    struct Message {
+        address target;
+        uint64 nonce;
+        bytes payload;
+    }
+
+    // struct MMRLeaf {
+    //     bytes32 blockHash;
+    //     bytes32 beefyNextAuthoritySetRoot;
+    // }
+
+    event MessageDispatched(uint64 nonce, bool result);
+
+    ILightClientBridge public lightClientBridge;
+
+    constructor(ILightClientBridge _lightClientBridge) public {
+        nonce = 0;
+        lightClientBridge = _lightClientBridge;
+    }
+
+    // TODO: Submit should take in all inputs required for verification,
+    function submit(
+        Message[] memory messages,
+        bytes memory beefyMMRLeaf,
+        uint256 beefyMMRLeafIndex,
+        uint256 beefyMMRLeafCount,
+        bytes32[] memory peaks,
+        bytes32[] memory siblings 
+    ) public {
+        require(
+            lightClientBridge.verifyBeefyMerkleLeaf(
+                beefyMMRLeaf,
+                beefyMMRLeafIndex,
+                beefyMMRLeafCount,
+                peaks,
+                siblings
+            ),
+            "Invalid proof"
+        );
+        verifyMessages(messages, beefyMMRLeaf);
+        processMessages(messages);
+    }
+
+    // struct BlockHeader {
+    //     parentHash bytes32;
+    //     number uint64;
+    //     stateRoot bytes32;
+    //     extrinsicsRoot bytes32;
+    //     digest bytes;
+    //     messagesRoot bytes32;
+    // }
+    //TODO: verifyMessages should accept all needed proofs
+    function verifyMessages(Message[] memory messages, bytes memory /*beefyMMRLeaf*/)
+        internal
+        view
+        returns (bool success)
+    {
+
+        // Scale.decodeBeefyMMRLeaf(beefyMMRLeaf)
+        // Scale.decodeBlockHeader(beefyMMRLeaf.BlockHeader)
+        // require(
+        //     blockHeader.BlockNumber <= lightClientBridge.getFinalizedBlockNumber(),
+        //     "block not finalized"
+        // )
+
+        // Validate that the commitment matches the commitment contents
+        // require(
+        //     validateMessagesMatchCommitment(messages, blockHeader.messageRoot),
+        //     "invalid messages"
+        // );
+
+        // Require there is enough gas to play all messages
+        require(
+            gasleft() >= messages.length * MAX_GAS_PER_MESSAGE,
+            "insufficient gas for delivery of all messages"
+        );
+
+        return true;
+    }
+
+    function processMessages(Message[] memory messages) internal {
+        for (uint256 i = 0; i < messages.length; i++) {
+            // Check message nonce is correct and increment nonce for replay protection
+            require(messages[i].nonce == nonce + 1, "invalid nonce");
+
+            nonce = nonce + 1;
+
+            // Deliver the message to the target
+            (bool success, ) =
+                messages[i].target.call{value: 0, gas: MAX_GAS_PER_MESSAGE}(
+                    messages[i].payload
+                );
+
+            emit MessageDispatched(messages[i].nonce, success);
+        }
+    }
+
+    function validateMessagesMatchCommitment(
+        Message[] memory messages,
+        bytes32 commitment
+    ) internal pure returns (bool) {
+        return keccak256(abi.encode(messages)) == commitment;
+    }
+}

--- a/contracts/bridge/contracts/BasicOutboundChannel.sol
+++ b/contracts/bridge/contracts/BasicOutboundChannel.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.0 <0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "./interfaces/IOutboundChannel.sol";
+
+// BasicOutboundChannel is a basic channel that just sends messages with a nonce.
+contract BasicOutboundChannel is IOutboundChannel {
+
+    uint64 public nonce;
+
+    event Message(
+        address source,
+        uint64 nonce,
+        bytes payload
+    );
+
+    /**
+     * @dev Sends a message across the channel
+     */
+    function submit(address, bytes calldata payload) external override {
+        nonce = nonce + 1;
+        emit Message(msg.sender, nonce, payload);
+    }
+}

--- a/contracts/bridge/contracts/LightClientBridge.sol
+++ b/contracts/bridge/contracts/LightClientBridge.sol
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity >=0.6.0 <0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelin/contracts/proxy/Initializable.sol";
+import "@darwinia/contracts-utils/contracts/Pausable.sol";
+import "@darwinia/contracts-utils/contracts/ECDSA.sol";
+import "@darwinia/contracts-utils/contracts/SafeMath.sol";
+import "@darwinia/contracts-utils/contracts/Bits.sol";
+import "@darwinia/contracts-utils/contracts/Bitfield.sol";
+import "./ValidatorRegistry.sol";
+
+contract LightClientBridge is Pausable, Initializable, ValidatorRegistry {
+    using SafeMath for uint256;
+    using Bits for uint256;
+    using Bitfield for uint256[];
+
+    /* Events */
+
+    /**
+     * @notice Notifies an observer that the prover's attempt at initital
+     * verification was successful.
+     * @dev Note that the prover must wait until `n` blocks have been mined
+     * subsequent to the generation of this event before the 2nd tx can be sent
+     * @param prover The address of the calling prover
+     * @param blockNumber The blocknumber in which the initial validation
+     * succeeded
+     * @param id An identifier to provide disambiguation
+     */
+    event InitialVerificationSuccessful(
+        address prover,
+        uint256 blockNumber,
+        uint256 id
+    );
+
+    /**
+     * @notice Notifies an observer that the complete verification process has
+     *  finished successfuly and the new commitmentHash will be accepted
+     * @param prover The address of the successful prover
+     * @param commitmentHash the commitmentHash which was approved for inclusion
+     * @param id the identifier used
+     */
+    event FinalVerificationSuccessful(
+        address prover,
+        bytes32 commitmentHash,
+        uint256 id
+    );
+
+    event NewMMRRoot(bytes32 mmrRoot, uint256 blockNumber);
+
+    /* Types */
+
+    struct Commitment {
+        bytes32 payload;
+        uint256 blockNumber;
+        uint256 validatorSetId;
+    }
+
+    struct ValidationData {
+        bytes32 commitmentHash;
+        uint256[] validatorClaimsBitfield;
+        uint256 blockNumber;
+    }
+
+    /* State */
+
+    uint256 public currentId;
+    bytes32 public latestMMRRoot;
+    uint256 public latestBlockNumber;
+    mapping(uint256 => ValidationData) public validationData;
+
+    /* Constants */
+
+    uint256 public constant PICK_NUMERATOR = 1;
+    uint256 public constant THRESHOLD_NUMERATOR = 2;
+    uint256 public constant THRESHOLD_DENOMINATOR = 3;
+    uint256 public constant BLOCK_WAIT_PERIOD = 45;
+
+    /**
+     * @notice Deploys the LightClientBridge contract
+     * @param _validatorSetRoot initial validator set merkle tree root
+     * @param _numOfValidators number of initial validator set
+     */
+    constructor(bytes32 _validatorSetRoot, uint256 _numOfValidators)
+        public
+        ValidatorRegistry(_validatorSetRoot, _numOfValidators) {}
+
+    /* Public Functions */
+
+    /**
+     * @notice Executed by the prover in order to begin the process of block
+     * acceptance by the light client
+     * @param commitmentHash contains the commitmentHash signed by the validator(s)
+     * @param validatorClaimsBitfield a bitfield containing a membership status of each
+     * validator who has claimed to have signed the commitmentHash
+     * @param validatorSignature the signature of one validator
+     * @param validatorPosition the position of the validator, index starting at 0
+     * @param validatorPublicKey the public key of the validator
+     * @param validatorPublicKeyMerkleProof proof required for validation of the public key in the validator merkle tree
+     */
+    function newSignatureCommitment(
+        bytes32 commitmentHash,
+        uint256[] calldata validatorClaimsBitfield,
+        bytes calldata validatorSignature,
+        uint256 validatorPosition,
+        address validatorPublicKey,
+        bytes32[] calldata validatorPublicKeyMerkleProof
+    ) external payable {
+        /**
+         * @dev Check if validatorPublicKeyMerkleProof is valid based on ValidatorRegistry merkle root
+         */
+        require(
+            checkValidatorInSet(
+                validatorPublicKey,
+                validatorPosition,
+                validatorPublicKeyMerkleProof
+            ),
+            "Error: Sender must be in validator set at correct position"
+        );
+
+        /**
+         * @dev Check if validatorSignature is correct, ie. check if it matches
+         * the signature of senderPublicKey on the commitmentHash
+         */
+        require(
+            ECDSA.recover(commitmentHash, validatorSignature) ==
+                validatorPublicKey,
+            "Error: Invalid Signature"
+        );
+
+        /**
+         * @dev Check that the bitfield actually contains enough claims to be succesful, ie, > 2/3
+         */
+        require(
+            validatorClaimsBitfield.countSetBits() >
+                (numOfValidators * THRESHOLD_NUMERATOR) /
+                    THRESHOLD_DENOMINATOR,
+            "Error: Bitfield not enough validators"
+        );
+
+        /**
+         * @todo Lock up the sender stake as collateral
+         */
+        // TODO
+
+        // Accept and save the commitment
+        validationData[currentId] = ValidationData(
+            commitmentHash,
+            validatorClaimsBitfield,
+            block.number
+        );
+
+        emit InitialVerificationSuccessful(msg.sender, block.number, currentId);
+
+        currentId = currentId.add(1);
+    }
+
+    /**
+     * @notice Performs the second step in the validation logic
+     * @param id an identifying value generated in the previous transaction
+     * @param commitment contains the full commitment that was used for the commitmentHash
+     * @param signatures an array of signatures from the randomly chosen validators
+     * @param validatorPositions an array of bitfields from the chosen validators
+     * @param validatorPublicKeys an array of the public key of each signer
+     * @param validatorPublicKeyMerkleProofs an array of merkle proofs from the chosen validators
+     */
+    function completeSignatureCommitment(
+        uint256 id,
+        Commitment calldata commitment,
+        bytes[] calldata signatures,
+        uint256[] calldata validatorPositions,
+        address[] calldata validatorPublicKeys,
+        bytes32[][] calldata validatorPublicKeyMerkleProofs
+    ) external {
+        ValidationData storage data = validationData[id];
+
+        /**
+         * @dev verify that block wait period has passed
+         */
+        require(
+            block.number >= data.blockNumber.add(BLOCK_WAIT_PERIOD),
+            "Error: Block wait period not over"
+        );
+
+        /**
+         * @dev verify that sender is the same as in `newSignatureCommitment`
+         */
+        // require(
+        //     msg.sender == data.senderAddress,
+        //     "Error: Sender address does not match original validation data"
+        // );
+
+        uint256 requiredNumOfSignatures =
+            (numOfValidators * PICK_NUMERATOR) /
+                THRESHOLD_DENOMINATOR;
+
+        /**
+         * @dev verify that required number of signatures, positions, public keys and merkle proofs are
+         * submitted
+         */
+        require(
+            signatures.length == requiredNumOfSignatures,
+            "Error: Number of signatures does not match required"
+        );
+        require(
+            validatorPositions.length == requiredNumOfSignatures,
+            "Error: Number of validator positions does not match required"
+        );
+        require(
+            validatorPublicKeys.length == requiredNumOfSignatures,
+            "Error: Number of validator public keys does not match required"
+        );
+        require(
+            validatorPublicKeyMerkleProofs.length == requiredNumOfSignatures,
+            "Error: Number of validator public keys does not match required"
+        );
+
+        /**
+         * @dev Generate an array of numbers
+         */
+        uint256[] memory randomBitfield =
+            Bitfield.randomNBitsFromPrior(
+                getSeed(data),
+                data.validatorClaimsBitfield,
+                requiredNumOfSignatures
+            );
+
+        /**
+         * @dev Encode and hash the commitment
+         */
+        bytes32 commitmentHash =
+            keccak256(
+                abi.encodePacked(
+                    commitment.payload,
+                    commitment.blockNumber,
+                    commitment.validatorSetId
+                )
+            );
+
+        require(
+            commitmentHash == data.commitmentHash,
+            "Error: Commitment must match commitment hash"
+        );
+
+        /**
+         *  @dev For each randomSignature, do:
+         */
+        for (uint256 i = 0; i < requiredNumOfSignatures; i++) {
+            /**
+             * @dev Check if validator in randomBitfield
+             */
+            require(
+                randomBitfield.isSet(validatorPositions[i]),
+                "Error: Validator must be once in bitfield"
+            );
+
+            /**
+             * @dev Remove validator from randomBitfield such that no validator can appear twice in signatures
+             */
+            randomBitfield.clear(validatorPositions[i]);
+
+            /**
+             * @dev Check if merkle proof is valid
+             */
+            require(
+                checkValidatorInSet(
+                    validatorPublicKeys[i],
+                    validatorPositions[i],
+                    validatorPublicKeyMerkleProofs[i]
+                ),
+                "Error: Validator must be in validator set at correct position"
+            );
+
+            /**
+             * @dev Check if signature is correct
+             */
+            require(
+                ECDSA.recover(commitmentHash, signatures[i]) ==
+                    validatorPublicKeys[i],
+                "Error: Invalid Signature"
+            );
+        }
+
+        /**
+         * @follow-up Do we need a try-catch block here?
+         */
+        processPayload(commitment.payload, commitment.blockNumber);
+
+        emit FinalVerificationSuccessful(msg.sender, commitmentHash, id);
+
+        /**
+         * @dev We no longer need the data held in state, so delete it for a gas refund
+         */
+        delete validationData[id];
+    }
+
+    /* Private Functions */
+
+    /**
+     * @notice Deterministically generates a seed from the block hash at the block number of creation of the validation
+     * data plus MAXIMUM_NUM_SIGNERS
+     * @dev Note that `blockhash(blockNum)` will only work for the 256 most recent blocks. If
+     * `completeSignatureCommitment` is called too late, a new call to `newSignatureCommitment` is necessary to reset
+     * validation data's block number
+     * @param data a storage reference to the validationData struct
+     * @return onChainRandNums an array storing the random numbers generated inside this function
+     */
+    function getSeed(ValidationData storage data)
+        private
+        view
+        returns (uint256)
+    {
+        // @note Get payload.blocknumber, add BLOCK_WAIT_PERIOD
+        uint256 randomSeedBlockNum = data.blockNumber.add(BLOCK_WAIT_PERIOD);
+        // @note Create a hash seed from the block number
+        bytes32 randomSeedBlockHash = blockhash(randomSeedBlockNum);
+
+        return uint256(randomSeedBlockHash);
+    }
+
+    /**
+     * @notice Perform some operation[s] using the payload
+     * @param payload The payload variable passed in via the initial function
+     */
+    function processPayload(bytes32 payload, uint256 blockNumber) private {
+        // Check the payload is newer than the latest
+        // Check that payload.leaf.block_number is > last_known_block_number;
+
+        latestMMRRoot = payload;
+        latestBlockNumber = blockNumber;
+        emit NewMMRRoot(latestMMRRoot, blockNumber);
+
+        // if payload is in next epoch, then apply validatorset changes
+        // if payload is not in current or next epoch, reject
+
+        applyValidatorSetChanges(payload);
+    }
+
+    /**
+     * @notice Check if the payload includes a new validator set,
+     * and if it does then update the new validator set
+     * @dev This function should call out to the validator registry contract
+     * @param payload The value to check if changes are required
+     */
+    function applyValidatorSetChanges(bytes32 payload) private {
+        // @todo Implement this function
+        // payload should contain a new root AND a MMR proof to the newest leaf
+        // check proof is for the newest leaf and is valid
+        // in the new leaf we should have
+        /*
+        MmrLeaf {
+            block_number: int
+			parent_hash: frame_system::Module::<T>::leaf_data(),
+			parachain_heads: Module::<T>::parachain_heads_merkle_root(),
+			beefy_authority_set: Module::<T>::beefy_authority_set_merkle_root(),
+		}
+        */
+        // get beefy_authority_set from newest leaf
+        // update authority set
+        // updateValidatorSet(payload);
+    }
+}

--- a/contracts/bridge/contracts/LightClientBridge.sol
+++ b/contracts/bridge/contracts/LightClientBridge.sol
@@ -10,6 +10,8 @@ import "@darwinia/contracts-utils/contracts/SafeMath.sol";
 import "@darwinia/contracts-utils/contracts/Bits.sol";
 import "@darwinia/contracts-utils/contracts/Bitfield.sol";
 import "@darwinia/contracts-utils/contracts/ScaleCodec.sol";
+import "@darwinia/contracts-verify/contracts/MerkleProof.sol";
+import "@darwinia/contracts-verify/contracts/MMR.sol";
 import "./ValidatorRegistry.sol";
 
 contract LightClientBridge is Pausable, Initializable, ValidatorRegistry {
@@ -102,6 +104,32 @@ contract LightClientBridge is Pausable, Initializable, ValidatorRegistry {
     }
 
     /* Public Functions */
+
+    /**
+     * @notice Executed by the apps in order to verify commitment
+     * @param MMRLeafIndex contains the merkle leaf index
+     * @param blockNumber contains the merkle leaf block number
+     * @param blockHeader contains the merkle leaf block header
+     * @param peaks contains the merkle maintain range peaks
+     * @param siblings contains the merkle maintain range siblings
+     */
+    function verifyMerkleLeaf(
+        uint256 MMRLeafIndex,
+        uint256 blockNumber,
+        bytes calldata blockHeader,
+        bytes32[] calldata peaks,
+        bytes32[] calldata siblings 
+    ) external view returns (bool) {
+        return
+            MMR.inclusionProof(
+                latestMMRRoot,
+                MMRLeafIndex + 1,
+                blockNumber,
+                blockHeader,
+                peaks,
+                siblings
+            );
+    }
 
     /**
      * @notice Executed by the prover in order to begin the process of block

--- a/contracts/bridge/contracts/LightClientBridge.sol
+++ b/contracts/bridge/contracts/LightClientBridge.sol
@@ -110,27 +110,31 @@ contract LightClientBridge is Pausable, Initializable, ValidatorRegistry {
 
     /* Public Functions */
 
+    function getFinalizedBlockNumber() external view returns (uint256) {
+        return latestBlockNumber;
+    }
+
     /**
      * @notice Executed by the apps in order to verify commitment
-     * @param MMRLeafIndex contains the merkle leaf index
-     * @param blockNumber contains the merkle leaf block number
-     * @param blockHeader contains the merkle leaf block header
+     * @param beefyMMRLeaf contains the merkle leaf
+     * @param beefyMMRLeafIndex contains the merkle leaf index
+     * @param beefyMMRLeafCount contains the merkle leaf count
      * @param peaks contains the merkle maintain range peaks
      * @param siblings contains the merkle maintain range siblings
      */
-    function verifyMerkleLeaf(
-        uint256 MMRLeafIndex,
-        uint256 blockNumber,
-        bytes calldata blockHeader,
+    function verifyBeefyMerkleLeaf(
+        bytes calldata beefyMMRLeaf,
+        uint256 beefyMMRLeafIndex,
+        uint256 beefyMMRLeafCount,
         bytes32[] calldata peaks,
         bytes32[] calldata siblings 
     ) external view returns (bool) {
         return
             MMR.inclusionProof(
                 latestMMRRoot,
-                MMRLeafIndex + 1,
-                blockNumber,
-                blockHeader,
+                beefyMMRLeafCount,
+                beefyMMRLeafIndex,
+                beefyMMRLeaf,
                 peaks,
                 siblings
             );

--- a/contracts/bridge/contracts/LightClientBridge.sol
+++ b/contracts/bridge/contracts/LightClientBridge.sol
@@ -388,7 +388,6 @@ contract LightClientBridge is Pausable, Initializable, ValidatorRegistry {
     function processPayload(uint256 nextValidatorSetId, Payload memory payload, uint256 blockNumber) private {
         // Check the payload is newer than the latest
         // Check that payload.leaf.block_number is > last_known_block_number;
-
         require(blockNumber > latestBlockNumber, "Error: Import old block");
         latestMMRRoot = payload.mmr;
         latestBlockNumber = blockNumber;
@@ -396,16 +395,10 @@ contract LightClientBridge is Pausable, Initializable, ValidatorRegistry {
 
         // if payload is in next epoch, then apply validatorset changes
         // if payload is not in current or next epoch, reject
-        if (nextValidatorSetId > validatorSetId) {
-            applyValidatorSetChanges(nextValidatorSetId, payload.nextValidatorSetRoot, payload.nextNumOfValidatorSet);
+        require(nextValidatorSetId == validatorSetId || nextValidatorSetId == validatorSetId + 1, "Invalid validator set id");
+        if (nextValidatorSetId == validatorSetId + 1) {
+            _update(nextValidatorSetId, nextValidatorSetRoot, numOfValidators);
         }
     }
 
-    /**
-     * @notice Check if the payload includes a new validator set,
-     * and if it does then update the new validator set
-     */
-    function applyValidatorSetChanges(uint256 nextValidatorSetId, bytes32 nextValidatorSetRoot, uint256 numOfValidators) private {
-        _update(nextValidatorSetId, nextValidatorSetRoot, numOfValidators);
-    }
 }

--- a/contracts/bridge/contracts/LightClientBridge.sol
+++ b/contracts/bridge/contracts/LightClientBridge.sol
@@ -98,14 +98,14 @@ contract LightClientBridge is Pausable, Initializable, ValidatorRegistry {
      * @param _validatorSetRoot initial validator set merkle tree root
      * @param _numOfValidators number of initial validator set
      */
-    function initialize(uint256 _validatorSetId, bytes32 _validatorSetRoot, uint256 _numOfValidators)
+    function initialize(bytes32 _validatorSetRoot, uint256 _validatorSetId, uint256 _numOfValidators)
         public
         initializer
     {
         ownableConstructor();
         pausableConstructor();
 
-        _update(_validatorSetId, _validatorSetRoot, _numOfValidators);
+        _update(_validatorSetRoot, _validatorSetId, _numOfValidators);
     }
 
     /* Public Functions */
@@ -267,7 +267,15 @@ contract LightClientBridge is Pausable, Initializable, ValidatorRegistry {
         //     "Error: Sender address does not match original validation data"
         // );
 
-        verifySigatures(commitmentHash, data.blockNumber, data.validatorClaimsBitfield, signatures, validatorPositions, validatorPublicKeys, validatorPublicKeyMerkleProofs);
+        verifySigatures(
+            commitmentHash,
+            data.blockNumber,
+            data.validatorClaimsBitfield,
+            signatures,
+            validatorPositions,
+            validatorPublicKeys,
+            validatorPublicKeyMerkleProofs
+        );
 
         /**
          * @follow-up Do we need a try-catch block here?
@@ -410,7 +418,7 @@ contract LightClientBridge is Pausable, Initializable, ValidatorRegistry {
         // TODO: check nextValidatorSet can null or not
         require(payload.nextValidatorSet.id == 0 || payload.nextValidatorSet.id == validatorSetId + 1, "Invalid next validator set id");
         if (payload.nextValidatorSet.id == validatorSetId + 1) {
-            _update(payload.nextValidatorSet.id, payload.nextValidatorSet.root, payload.nextValidatorSet.len);
+            _update(payload.nextValidatorSet.root, payload.nextValidatorSet.id, payload.nextValidatorSet.len);
         }
     }
 

--- a/contracts/bridge/contracts/ValidatorRegistry.sol
+++ b/contracts/bridge/contracts/ValidatorRegistry.sol
@@ -31,10 +31,12 @@ contract ValidatorRegistry is Ownable {
     /**
      * @notice Updates the validator registry and number of validators
      * @param _root The new root
+     * @param _validatorSetId The new validators id
      * @param _numOfValidators The new number of validators
      */
-    function _update(uint256 _validatorSetId, bytes32 _root, uint256 _numOfValidators) internal {
+    function _update(bytes32 _root, uint256 _validatorSetId, uint256 _numOfValidators) internal {
         root = _root;
+        validatorSetId = _validatorSetId;
         numOfValidators = _numOfValidators;
         emit ValidatorRegistryUpdated(_root, _numOfValidators);
     }

--- a/contracts/bridge/contracts/ValidatorRegistry.sol
+++ b/contracts/bridge/contracts/ValidatorRegistry.sol
@@ -9,36 +9,29 @@ import "@darwinia/contracts-verify/contracts/MerkleProof.sol";
 /**
  * @title A contract storing state on the current validator set
  * @dev Stores the validator set as a Merkle root
- * @dev Inherits `Ownable` to ensure it can only be callable by the
- * instantiating contract account (which is the LightClientBridge contract)
  */
 contract ValidatorRegistry is Ownable {
     /* Events */
 
-    event ValidatorRegistryUpdated(bytes32 root, uint256 numOfValidators);
+    event ValidatorRegistryUpdated(bytes32 validatorSetRoot, uint256 numOfValidators);
 
     /* State */
 
-    bytes32 public root;
+    bytes32 public validatorSetRoot;
     uint256 public validatorSetId;
     uint256 public numOfValidators;
 
-    // constructor(bytes32 _root, uint256 _numOfValidators) public {
-    //     root = _root;
-    //     numOfValidators = _numOfValidators;
-    // }
-
     /**
-     * @notice Updates the validator registry and number of validators
-     * @param _root The new root
-     * @param _validatorSetId The new validators id
-     * @param _numOfValidators The new number of validators
+     * @notice Updates the validator set
+     * @param _validatorSetRoot The new validator set root
+     * @param _validatorSetId The new validator set id
+     * @param _numOfValidators The new number of validator set
      */
-    function _update(bytes32 _root, uint256 _validatorSetId, uint256 _numOfValidators) internal {
-        root = _root;
+    function _update(bytes32 _validatorSetRoot, uint256 _validatorSetId, uint256 _numOfValidators) internal {
+        validatorSetRoot = _validatorSetRoot;
         validatorSetId = _validatorSetId;
         numOfValidators = _numOfValidators;
-        emit ValidatorRegistryUpdated(_root, _numOfValidators);
+        emit ValidatorRegistryUpdated(_validatorSetRoot, _numOfValidators);
     }
 
     /**
@@ -56,7 +49,7 @@ contract ValidatorRegistry is Ownable {
         bytes32 hashedLeaf = keccak256(abi.encodePacked(addr));
         return
             MerkleProof.verifyMerkleLeafAtPosition(
-                root,
+                validatorSetRoot,
                 hashedLeaf,
                 pos,
                 numOfValidators,

--- a/contracts/bridge/contracts/ValidatorRegistry.sol
+++ b/contracts/bridge/contracts/ValidatorRegistry.sol
@@ -20,6 +20,7 @@ contract ValidatorRegistry is Ownable {
     /* State */
 
     bytes32 public root;
+    uint256 public validatorSetId;
     uint256 public numOfValidators;
 
     // constructor(bytes32 _root, uint256 _numOfValidators) public {
@@ -32,11 +33,8 @@ contract ValidatorRegistry is Ownable {
      * @param _root The new root
      * @param _numOfValidators The new number of validators
      */
-    function update(bytes32 _root, uint256 _numOfValidators) public onlyOwner {
-        _update(_root, _numOfValidators);
-    }
-
-    function _update(bytes32 _root, uint256 _numOfValidators) internal {
+    function _update(uint256 _validatorSetId, bytes32 _root, uint256 _numOfValidators) internal {
+        require(_validatorSetId == validatorSetId + 1, "Error: Invalid validator set id");
         root = _root;
         numOfValidators = _numOfValidators;
         emit ValidatorRegistryUpdated(_root, _numOfValidators);

--- a/contracts/bridge/contracts/ValidatorRegistry.sol
+++ b/contracts/bridge/contracts/ValidatorRegistry.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity >=0.6.0 <0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@darwinia/contracts-utils/contracts/Ownable.sol";
+import "@darwinia/contracts-verify/contracts/MerkleProof.sol";
+
+/**
+ * @title A contract storing state on the current validator set
+ * @dev Stores the validator set as a Merkle root
+ * @dev Inherits `Ownable` to ensure it can only be callable by the
+ * instantiating contract account (which is the LightClientBridge contract)
+ */
+contract ValidatorRegistry is Ownable {
+    /* Events */
+
+    event ValidatorRegistryUpdated(bytes32 root, uint256 numOfValidators);
+
+    /* State */
+
+    bytes32 public root;
+    uint256 public numOfValidators;
+
+    constructor(bytes32 _root, uint256 _numOfValidators) public {
+        root = _root;
+        numOfValidators = _numOfValidators;
+    }
+
+    /**
+     * @notice Updates the validator registry and number of validators
+     * @param _root The new root
+     * @param _numOfValidators The new number of validators
+     */
+    function update(bytes32 _root, uint256 _numOfValidators) public onlyOwner {
+        root = _root;
+        numOfValidators = _numOfValidators;
+        emit ValidatorRegistryUpdated(_root, _numOfValidators);
+    }
+
+    /**
+     * @notice Checks if a validators address is a member of the merkle tree
+     * @param addr The address of the validator to check
+     * @param pos The position of the validator to check, index starting at 0
+     * @param proof Merkle proof required for validation of the address
+     * @return Returns true if the validator is in the set
+     */
+    function checkValidatorInSet(
+        address addr,
+        uint256 pos,
+        bytes32[] memory proof
+    ) public view returns (bool) {
+        bytes32 hashedLeaf = keccak256(abi.encodePacked(addr));
+        return
+            MerkleProof.verifyMerkleLeafAtPosition(
+                root,
+                hashedLeaf,
+                pos,
+                numOfValidators,
+                proof
+            );
+    }
+}

--- a/contracts/bridge/contracts/ValidatorRegistry.sol
+++ b/contracts/bridge/contracts/ValidatorRegistry.sol
@@ -34,7 +34,6 @@ contract ValidatorRegistry is Ownable {
      * @param _numOfValidators The new number of validators
      */
     function _update(uint256 _validatorSetId, bytes32 _root, uint256 _numOfValidators) internal {
-        require(_validatorSetId == validatorSetId + 1, "Error: Invalid validator set id");
         root = _root;
         numOfValidators = _numOfValidators;
         emit ValidatorRegistryUpdated(_root, _numOfValidators);

--- a/contracts/bridge/contracts/ValidatorRegistry.sol
+++ b/contracts/bridge/contracts/ValidatorRegistry.sol
@@ -22,10 +22,10 @@ contract ValidatorRegistry is Ownable {
     bytes32 public root;
     uint256 public numOfValidators;
 
-    constructor(bytes32 _root, uint256 _numOfValidators) public {
-        root = _root;
-        numOfValidators = _numOfValidators;
-    }
+    // constructor(bytes32 _root, uint256 _numOfValidators) public {
+    //     root = _root;
+    //     numOfValidators = _numOfValidators;
+    // }
 
     /**
      * @notice Updates the validator registry and number of validators
@@ -33,6 +33,10 @@ contract ValidatorRegistry is Ownable {
      * @param _numOfValidators The new number of validators
      */
     function update(bytes32 _root, uint256 _numOfValidators) public onlyOwner {
+        _update(_root, _numOfValidators);
+    }
+
+    function _update(bytes32 _root, uint256 _numOfValidators) internal {
         root = _root;
         numOfValidators = _numOfValidators;
         emit ValidatorRegistryUpdated(_root, _numOfValidators);

--- a/contracts/bridge/contracts/interfaces/ILightClientBridge.sol
+++ b/contracts/bridge/contracts/interfaces/ILightClientBridge.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.0 <0.7.0;
+pragma experimental ABIEncoderV2;
+
+interface ILightClientBridge {
+    struct NextValidatorSet {
+        bytes32 root;
+        uint64 id;
+        uint64 len; 
+    }
+
+    struct Payload {
+        bytes32 mmr;
+        NextValidatorSet nextValidatorSet; 
+    }
+
+    struct Commitment {
+        Payload payload;
+        uint64 blockNumber;
+        uint64 validatorSetId;
+    }
+
+    function newSignatureCommitment(
+        bytes32 commitmentHash,
+        uint256[] calldata validatorClaimsBitfield,
+        bytes calldata validatorSignature,
+        uint256 validatorPosition,
+        address validatorPublicKey,
+        bytes32[] calldata validatorPublicKeyMerkleProof
+    ) external; 
+
+    function completeSignatureCommitment(
+        uint256 id,
+        Commitment calldata commitment,
+        bytes[] calldata signatures,
+        uint256[] calldata validatorPositions,
+        address[] calldata validatorPublicKeys,
+        bytes32[][] calldata validatorPublicKeyMerkleProofs
+    ) external; 
+
+    function verifyBeefyMerkleLeaf(
+        bytes calldata beefyMMRLeaf,
+        uint256 beefyMMRLeafIndex,
+        uint256 beefyMMRLeafCount,
+        bytes32[] calldata peaks,
+        bytes32[] calldata siblings 
+    ) external view returns (bool);
+
+    function getFinalizedBlockNumber() external view returns (uint256);
+}

--- a/contracts/bridge/contracts/interfaces/IOutboundChannel.sol
+++ b/contracts/bridge/contracts/interfaces/IOutboundChannel.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.0 <0.7.0;
+pragma experimental ABIEncoderV2;
+
+interface IOutboundChannel {
+    function submit(address origin, bytes calldata payload) external;
+}

--- a/contracts/bridge/hardhat.config.js
+++ b/contracts/bridge/hardhat.config.js
@@ -24,7 +24,7 @@ module.exports = {
   solidity: {
     compilers: [
       {
-        version: "0.6.0",
+        version: "0.6.7",
         settings: {
           evmVersion: "istanbul",
           optimizer: {

--- a/contracts/utils/contracts/Bitfield.sol
+++ b/contracts/utils/contracts/Bitfield.sol
@@ -1,0 +1,115 @@
+// "SPDX-License-Identifier: Apache-2.0"
+pragma solidity >=0.6.0 <0.7.0;
+
+import "./Bits.sol";
+
+library Bitfield {
+    /**
+     * @dev Constants used to efficiently calculate the hamming weight of a bitfield. See
+     * https://en.wikipedia.org/wiki/Hamming_weight#Efficient_implementation for an explanation of those constants.
+     */
+    uint256 internal constant M1 =
+        0x5555555555555555555555555555555555555555555555555555555555555555;
+    uint256 internal constant M2 =
+        0x3333333333333333333333333333333333333333333333333333333333333333;
+    uint256 internal constant M4 =
+        0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f;
+    uint256 internal constant M8 =
+        0x00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff;
+    uint256 internal constant M16 =
+        0x0000ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000ffff;
+    uint256 internal constant M32 =
+        0x00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff;
+    uint256 internal constant M64 =
+        0x0000000000000000ffffffffffffffff0000000000000000ffffffffffffffff;
+    uint256 internal constant M128 =
+        0x00000000000000000000000000000000ffffffffffffffffffffffffffffffff;
+
+    uint256 internal constant ONE = uint256(1);
+    using Bits for uint256;
+
+    /**
+     * @notice Draws a random number, derives an index in the bitfield, and sets the bit if it is in the `prior` and not
+     * yet set. Repeats that `n` times.
+     */
+    function randomNBitsFromPrior(
+        uint256 seed,
+        uint256[] memory prior,
+        uint256 n
+    ) public pure returns (uint256[] memory bitfield) {
+        require(
+            n <= countSetBits(prior),
+            "`n` must be <= number of set bits in `prior`"
+        );
+
+        bitfield = new uint256[](prior.length);
+        uint256 found = 0;
+        uint256 length = prior.length * 256;
+
+        for (uint256 i = 0; found < n; i++) {
+            bytes32 randomness = keccak256(abi.encode(seed + i));
+            uint256 index = uint256(randomness) % length;
+
+            // require randomly seclected bit to be set in prior
+            if (!isSet(prior, index)) {
+                continue;
+            }
+
+            // require a not yet sit (new) bit to be set
+            if (isSet(bitfield, index)) {
+                continue;
+            }
+
+            set(bitfield, index);
+
+            found++;
+        }
+
+        return bitfield;
+    }
+
+    /**
+     * @notice Calculates the number of set bits by using the hamming weight of the bitfield.
+     * The alogrithm below is implemented after https://en.wikipedia.org/wiki/Hamming_weight#Efficient_implementation.
+     * Further improvements are possible, see the article above.
+     */
+    function countSetBits(uint256[] memory self) public pure returns (uint256) {
+        uint256 count = 0;
+        for (uint256 i = 0; i < self.length; i++) {
+            uint256 x = self[i];
+
+            x = (x & M1) + ((x >> 1) & M1); //put count of each  2 bits into those  2 bits
+            x = (x & M2) + ((x >> 2) & M2); //put count of each  4 bits into those  4 bits
+            x = (x & M4) + ((x >> 4) & M4); //put count of each  8 bits into those  8 bits
+            x = (x & M8) + ((x >> 8) & M8); //put count of each 16 bits into those 16 bits
+            x = (x & M16) + ((x >> 16) & M16); //put count of each 32 bits into those 32 bits
+            x = (x & M32) + ((x >> 32) & M32); //put count of each 64 bits into those 64 bits
+            x = (x & M64) + ((x >> 64) & M64); //put count of each 128 bits into those 128 bits
+            x = (x & M128) + ((x >> 128) & M128); //put count of each 256 bits into those 256 bits
+            count += x;
+        }
+        return count;
+    }
+
+    function isSet(uint256[] memory self, uint256 index)
+        internal
+        pure
+        returns (bool)
+    {
+        uint256 element = index / 256;
+        uint8 within = uint8(index % 256);
+        return self[element].bit(within) == 1;
+    }
+
+    function set(uint256[] memory self, uint256 index) internal pure {
+        uint256 element = index / 256;
+        uint8 within = uint8(index % 256);
+        self[element] = self[element].setBit(within);
+    }
+
+    function clear(uint256[] memory self, uint256 index) internal pure {
+        uint256 element = index / 256;
+        uint8 within = uint8(index % 256);
+        self[element] = self[element].clearBit(within);
+    }
+}

--- a/contracts/utils/contracts/Bitfield.sol
+++ b/contracts/utils/contracts/Bitfield.sol
@@ -1,4 +1,4 @@
-// "SPDX-License-Identifier: Apache-2.0"
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.6.0 <0.7.0;
 
 import "./Bits.sol";
@@ -36,7 +36,7 @@ library Bitfield {
         uint256 seed,
         uint256[] memory prior,
         uint256 n
-    ) public pure returns (uint256[] memory bitfield) {
+    ) internal pure returns (uint256[] memory bitfield) {
         require(
             n <= countSetBits(prior),
             "`n` must be <= number of set bits in `prior`"
@@ -73,7 +73,7 @@ library Bitfield {
      * The alogrithm below is implemented after https://en.wikipedia.org/wiki/Hamming_weight#Efficient_implementation.
      * Further improvements are possible, see the article above.
      */
-    function countSetBits(uint256[] memory self) public pure returns (uint256) {
+    function countSetBits(uint256[] memory self) internal pure returns (uint256) {
         uint256 count = 0;
         for (uint256 i = 0; i < self.length; i++) {
             uint256 x = self[i];

--- a/contracts/utils/contracts/Bits.sol
+++ b/contracts/utils/contracts/Bits.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT
+// Code from https://github.com/ethereum/solidity-examples
+pragma solidity >=0.6.0 <0.7.0;
+pragma experimental ABIEncoderV2;
+
+library Bits {
+    uint256 internal constant ONE = uint256(1);
+    uint256 internal constant ONES = uint256(~0);
+
+    // Sets the bit at the given 'index' in 'self' to '1'.
+    // Returns the modified value.
+    function setBit(uint256 self, uint8 index) internal pure returns (uint256) {
+        return self | (ONE << index);
+    }
+
+    // Sets the bit at the given 'index' in 'self' to '0'.
+    // Returns the modified value.
+    function clearBit(uint256 self, uint8 index)
+        internal
+        pure
+        returns (uint256)
+    {
+        return self & ~(ONE << index);
+    }
+
+    // Sets the bit at the given 'index' in 'self' to:
+    //  '1' - if the bit is '0'
+    //  '0' - if the bit is '1'
+    // Returns the modified value.
+    function toggleBit(uint256 self, uint8 index)
+        internal
+        pure
+        returns (uint256)
+    {
+        return self ^ (ONE << index);
+    }
+
+    // Get the value of the bit at the given 'index' in 'self'.
+    function bit(uint256 self, uint8 index) internal pure returns (uint8) {
+        return uint8((self >> index) & 1);
+    }
+
+    // Check if the bit at the given 'index' in 'self' is set.
+    // Returns:
+    //  'true' - if the value of the bit is '1'
+    //  'false' - if the value of the bit is '0'
+    function bitSet(uint256 self, uint8 index) internal pure returns (bool) {
+        return (self >> index) & 1 == 1;
+    }
+
+    // Checks if the bit at the given 'index' in 'self' is equal to the corresponding
+    // bit in 'other'.
+    // Returns:
+    //  'true' - if both bits are '0' or both bits are '1'
+    //  'false' - otherwise
+    function bitEqual(
+        uint256 self,
+        uint256 other,
+        uint8 index
+    ) internal pure returns (bool) {
+        return ((self ^ other) >> index) & 1 == 0;
+    }
+
+    // Get the bitwise NOT of the bit at the given 'index' in 'self'.
+    function bitNot(uint256 self, uint8 index) internal pure returns (uint8) {
+        return uint8(1 - ((self >> index) & 1));
+    }
+
+    // Computes the bitwise AND of the bit at the given 'index' in 'self', and the
+    // corresponding bit in 'other', and returns the value.
+    function bitAnd(
+        uint256 self,
+        uint256 other,
+        uint8 index
+    ) internal pure returns (uint8) {
+        return uint8(((self & other) >> index) & 1);
+    }
+
+    // Computes the bitwise OR of the bit at the given 'index' in 'self', and the
+    // corresponding bit in 'other', and returns the value.
+    function bitOr(
+        uint256 self,
+        uint256 other,
+        uint8 index
+    ) internal pure returns (uint8) {
+        return uint8(((self | other) >> index) & 1);
+    }
+
+    // Computes the bitwise XOR of the bit at the given 'index' in 'self', and the
+    // corresponding bit in 'other', and returns the value.
+    function bitXor(
+        uint256 self,
+        uint256 other,
+        uint8 index
+    ) internal pure returns (uint8) {
+        return uint8(((self ^ other) >> index) & 1);
+    }
+
+    // Gets 'numBits' consecutive bits from 'self', starting from the bit at 'startIndex'.
+    // Returns the bits as a 'uint'.
+    // Requires that:
+    //  - '0 < numBits <= 256'
+    //  - 'startIndex < 256'
+    //  - 'numBits + startIndex <= 256'
+    function bits(
+        uint256 self,
+        uint8 startIndex,
+        uint16 numBits
+    ) internal pure returns (uint256) {
+        require(0 < numBits && startIndex < 256 && startIndex + numBits <= 256);
+        return (self >> startIndex) & (ONES >> (256 - numBits));
+    }
+
+    // Computes the index of the highest bit set in 'self'.
+    // Returns the highest bit set as an 'uint8'.
+    // Requires that 'self != 0'.
+    function highestBitSet(uint256 self) internal pure returns (uint8 highest) {
+        require(self != 0);
+        uint256 val = self;
+        for (uint8 i = 128; i >= 1; i >>= 1) {
+            if (val & (((ONE << i) - 1) << i) != 0) {
+                highest += i;
+                val >>= i;
+            }
+        }
+    }
+
+    // Computes the index of the lowest bit set in 'self'.
+    // Returns the lowest bit set as an 'uint8'.
+    // Requires that 'self != 0'.
+    function lowestBitSet(uint256 self) internal pure returns (uint8 lowest) {
+        require(self != 0);
+        uint256 val = self;
+        for (uint8 i = 128; i >= 1; i >>= 1) {
+            if (val & ((ONE << i) - 1) == 0) {
+                lowest += i;
+                val >>= i;
+            }
+        }
+    }
+}

--- a/contracts/utils/contracts/Keccak.sol
+++ b/contracts/utils/contracts/Keccak.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.7.0;
+
+import "./Memory.sol";
+
+library Keccak {
+
+    function hash(bytes memory src) internal pure returns (bytes32 des) {
+        return keccak256(src);
+    }
+}

--- a/contracts/utils/contracts/Keccak.sol
+++ b/contracts/utils/contracts/Keccak.sol
@@ -2,8 +2,6 @@
 
 pragma solidity >=0.6.0 <0.7.0;
 
-import "./Memory.sol";
-
 library Keccak {
 
     function hash(bytes memory src) internal pure returns (bytes32 des) {

--- a/contracts/utils/contracts/Node.sol
+++ b/contracts/utils/contracts/Node.sol
@@ -5,11 +5,12 @@ pragma solidity >=0.6.0 <0.7.0;
 import "./Input.sol";
 import "./Nibble.sol";
 import "./Bytes.sol";
-import "./Hash.sol";
+import "./Keccak.sol";
 import "./Scale.sol";
 
 library Node {
     using Input for Input.Data;
+    using Keccak for bytes;
     using Bytes for bytes;
 
     uint8 internal constant NODEKIND_NOEXT_LEAF = 1;
@@ -105,5 +106,131 @@ library Node {
             }
         }
         return key;
+    }
+
+    // encodeBranch encodes a branch
+    function encodeBranch(Branch memory b)
+        internal
+        pure
+        returns (bytes memory encoding)
+    {
+        encoding = encodeBranchHeader(b);
+        encoding = abi.encodePacked(encoding, Nibble.nibblesToKeyLE(b.key));
+        encoding = abi.encodePacked(encoding, u16ToBytes(childrenBitmap(b)));
+        if (b.value.length != 0) {
+            bytes memory encValue;
+            (encValue, ) = Scale.encodeByteArray(b.value);
+            encoding = abi.encodePacked(encoding, encValue);
+        }
+        for (uint8 i = 0; i < 16; i++) {
+            if (b.children[i].exist) {
+                //TODO::encode data
+                bytes memory childData = b.children[i].data;
+                require(childData.length > 0, "miss child data");
+                bytes memory hash;
+                if (childData.length <= 32) {
+                    hash = childData;
+                } else {
+                    hash = Memory.toBytes(childData.hash());
+                }
+                bytes memory encChild;
+                (encChild, ) = Scale.encodeByteArray(hash);
+                encoding = abi.encodePacked(encoding, encChild);
+            }
+        }
+        return encoding;
+    }
+
+    // encodeLeaf encodes a leaf
+    function encodeLeaf(Leaf memory l)
+        internal
+        pure
+        returns (bytes memory encoding)
+    {
+        encoding = encodeLeafHeader(l);
+        encoding = abi.encodePacked(encoding, Nibble.nibblesToKeyLE(l.key));
+        bytes memory encValue;
+        (encValue, ) = Scale.encodeByteArray(l.value);
+        encoding = abi.encodePacked(encoding, encValue);
+        return encoding;
+    }
+
+    function encodeBranchHeader(Branch memory b)
+        internal
+        pure
+        returns (bytes memory branchHeader)
+    {
+        uint8 header;
+        uint256 valueLen = b.value.length;
+        require(valueLen < 65536, "partial key too long");
+        if (valueLen == 0) {
+            header = 2 << 6; // w/o
+        } else {
+            header = 3 << 6; // w/
+        }
+        bytes memory encPkLen;
+        uint256 pkLen = b.key.length;
+        if (pkLen >= 63) {
+            header = header | 0x3F;
+            encPkLen = encodeExtraPartialKeyLength(uint16(pkLen));
+        } else {
+            header = header | uint8(pkLen);
+        }
+        branchHeader = abi.encodePacked(header, encPkLen);
+        return branchHeader;
+    }
+
+    function encodeLeafHeader(Leaf memory l)
+        internal
+        pure
+        returns (bytes memory leafHeader)
+    {
+        uint8 header = 1 << 6;
+        uint256 pkLen = l.key.length;
+        bytes memory encPkLen;
+        if (pkLen >= 63) {
+            header = header | 0x3F;
+            encPkLen = encodeExtraPartialKeyLength(uint16(pkLen));
+        } else {
+            header = header | uint8(pkLen);
+        }
+        leafHeader = abi.encodePacked(header, encPkLen);
+        return leafHeader;
+    }
+
+    function encodeExtraPartialKeyLength(uint16 pkLen)
+        internal
+        pure
+        returns (bytes memory encPkLen)
+    {
+        pkLen -= 63;
+        for (uint8 i = 0; i < 65536; i++) {
+            if (pkLen < 255) {
+                encPkLen = abi.encodePacked(encPkLen, uint8(pkLen));
+                break;
+            } else {
+                encPkLen = abi.encodePacked(encPkLen, uint8(255));
+            }
+        }
+        return encPkLen;
+    }
+
+    // u16ToBytes converts a uint16 into a 2-byte slice
+    function u16ToBytes(uint16 src) internal pure returns (bytes memory des) {
+        des = new bytes(2);
+        des[0] = bytes1(uint8(src & 0x00FF));
+        des[1] = bytes1(uint8((src >> 8) & 0x00FF));
+    }
+
+    function childrenBitmap(Branch memory b)
+        internal
+        pure
+        returns (uint16 bitmap)
+    {
+        for (uint256 i = 0; i < 16; i++) {
+            if (b.children[i].exist) {
+                bitmap = bitmap | uint16(1 << i);
+            }
+        }
     }
 }

--- a/contracts/utils/contracts/ScaleCodec.sol
+++ b/contracts/utils/contracts/ScaleCodec.sol
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.0 <0.7.0;
+
+library ScaleCodec {
+    // Decodes a SCALE encoded uint256 by converting bytes (bid endian) to little endian format
+    function decodeUint256(bytes memory data) public pure returns (uint256) {
+        uint256 number;
+        for (uint256 i = data.length; i > 0; i--) {
+            number = number + uint256(uint8(data[i - 1])) * (2**(8 * (i - 1)));
+        }
+        return number;
+    }
+
+    // Decodes a SCALE encoded compact unsigned integer
+    function decodeUintCompact(bytes memory data)
+        public
+        pure
+        returns (uint256 v)
+    {
+        uint8 b = readByteAtIndex(data, 0); // read the first byte
+        uint8 mode = b & 3; // bitwise operation
+
+        if (mode == 0) {
+            // [0, 63]
+            return b >> 2; // right shift to remove mode bits
+        } else if (mode == 1) {
+            // [64, 16383]
+            uint8 bb = readByteAtIndex(data, 1); // read the second byte
+            uint64 r = bb; // convert to uint64
+            r <<= 6; // multiply by * 2^6
+            r += b >> 2; // right shift to remove mode bits
+            return r;
+        } else if (mode == 2) {
+            // [16384, 1073741823]
+            uint8 b2 = readByteAtIndex(data, 1); // read the next 3 bytes
+            uint8 b3 = readByteAtIndex(data, 2);
+            uint8 b4 = readByteAtIndex(data, 3);
+
+            uint32 x1 = uint32(b) | (uint32(b2) << 8); // convert to little endian
+            uint32 x2 = x1 | (uint32(b3) << 16);
+            uint32 x3 = x2 | (uint32(b4) << 24);
+
+            x3 >>= 2; // remove the last 2 mode bits
+            return uint256(x3);
+        } else if (mode == 3) {
+            // [1073741824, 4503599627370496]
+            uint8 l = b >> 2; // remove mode bits
+            require(
+                l > 32,
+                "Not supported: number cannot be greater than 32 bytes"
+            );
+        } else {
+            revert("Code should be unreachable");
+        }
+    }
+
+    // Read a byte at a specific index and return it as type uint8
+    function readByteAtIndex(bytes memory data, uint8 index)
+        internal
+        pure
+        returns (uint8)
+    {
+        return uint8(data[index]);
+    }
+
+    // Sources:
+    //   * https://ethereum.stackexchange.com/questions/15350/how-to-convert-an-bytes-to-address-in-solidity/50528
+    //   * https://graphics.stanford.edu/~seander/bithacks.html#ReverseParallel
+
+    function reverse256(uint256 input) internal pure returns (uint256 v) {
+        v = input;
+
+        // swap bytes
+        v = ((v & 0xFF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00) >> 8) |
+            ((v & 0x00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF) << 8);
+
+        // swap 2-byte long pairs
+        v = ((v & 0xFFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000) >> 16) |
+            ((v & 0x0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF) << 16);
+
+        // swap 4-byte long pairs
+        v = ((v & 0xFFFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000) >> 32) |
+            ((v & 0x00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF) << 32);
+
+        // swap 8-byte long pairs
+        v = ((v & 0xFFFFFFFFFFFFFFFF0000000000000000FFFFFFFFFFFFFFFF0000000000000000) >> 64) |
+            ((v & 0x0000000000000000FFFFFFFFFFFFFFFF0000000000000000FFFFFFFFFFFFFFFF) << 64);
+
+        // swap 16-byte long pairs
+        v = (v >> 128) | (v << 128);
+    }
+
+    function reverse128(uint128 input) internal pure returns (uint128 v) {
+        v = input;
+
+        // swap bytes
+        v = ((v & 0xFF00FF00FF00FF00FF00FF00FF00FF00) >> 8) |
+            ((v & 0x00FF00FF00FF00FF00FF00FF00FF00FF) << 8);
+
+        // swap 2-byte long pairs
+        v = ((v & 0xFFFF0000FFFF0000FFFF0000FFFF0000) >> 16) |
+            ((v & 0x0000FFFF0000FFFF0000FFFF0000FFFF) << 16);
+
+        // swap 4-byte long pairs
+        v = ((v & 0xFFFFFFFF00000000FFFFFFFF00000000) >> 32) |
+            ((v & 0x00000000FFFFFFFF00000000FFFFFFFF) << 32);
+
+        // swap 8-byte long pairs
+        v = (v >> 64) | (v << 64);
+    }
+
+    function reverse64(uint64 input) internal pure returns (uint64 v) {
+        v = input;
+
+        // swap bytes
+        v = ((v & 0xFF00FF00FF00FF00) >> 8) |
+            ((v & 0x00FF00FF00FF00FF) << 8);
+
+        // swap 2-byte long pairs
+        v = ((v & 0xFFFF0000FFFF0000) >> 16) |
+            ((v & 0x0000FFFF0000FFFF) << 16);
+
+        // swap 4-byte long pairs
+        v = (v >> 32) | (v << 32);
+    }
+
+    function reverse32(uint32 input) internal pure returns (uint32 v) {
+        v = input;
+
+        // swap bytes
+        v = ((v & 0xFF00FF00) >> 8) |
+            ((v & 0x00FF00FF) << 8);
+
+        // swap 2-byte long pairs
+        v = (v >> 16) | (v << 16);
+    }
+
+    function reverse16(uint16 input) internal pure returns (uint16 v) {
+        v = input;
+
+        // swap bytes
+        v = (v >> 8) | (v << 8);
+    }
+
+    function encode256(uint256 input) public pure returns (bytes32) {
+        return bytes32(reverse256(input));
+    }
+
+    function encode128(uint128 input) public pure returns (bytes16) {
+        return bytes16(reverse128(input));
+    }
+
+    function encode64(uint64 input) public pure returns (bytes8) {
+        return bytes8(reverse64(input));
+    }
+
+    function encode32(uint32 input) public pure returns (bytes4) {
+        return bytes4(reverse32(input));
+    }
+
+    function encode16(uint16 input) public pure returns (bytes2) {
+        return bytes2(reverse16(input));
+    }
+}

--- a/contracts/verify/contracts/CompactMerkleProof.sol
+++ b/contracts/verify/contracts/CompactMerkleProof.sol
@@ -1,0 +1,403 @@
+// SPDX-License-Identifier: MIT
+
+// Modified Merkle-Patricia Trie
+//
+// Note that for the following definitions, `|` denotes concatenation
+//
+// Branch encoding:
+// NodeHeader | Extra partial key length | Partial Key | Value
+// `NodeHeader` is a byte such that:
+// most significant two bits of `NodeHeader`: 10 if branch w/o value, 11 if branch w/ value
+// least significant six bits of `NodeHeader`: if len(key) > 62, 0x3f, otherwise len(key)
+// `Extra partial key length` is included if len(key) > 63 and consists of the remaining key length
+// `Partial Key` is the branch's key
+// `Value` is: Children Bitmap | SCALE Branch node Value | Hash(Enc(Child[i_1])) | Hash(Enc(Child[i_2])) | ... | Hash(Enc(Child[i_n]))
+//
+// Leaf encoding:
+// NodeHeader | Extra partial key length | Partial Key | Value
+// `NodeHeader` is a byte such that:
+// most significant two bits of `NodeHeader`: 01
+// least significant six bits of `NodeHeader`: if len(key) > 62, 0x3f, otherwise len(key)
+// `Extra partial key length` is included if len(key) > 63 and consists of the remaining key length
+// `Partial Key` is the leaf's key
+// `Value` is the leaf's SCALE encoded value
+
+pragma solidity >=0.6.0 <0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@darwinia/contracts-utils/contracts/Input.sol";
+import "@darwinia/contracts-utils/contracts/Memory.sol";
+import "@darwinia/contracts-utils/contracts/Bytes.sol";
+import "@darwinia/contracts-utils/contracts/Keccak.sol";
+import "@darwinia/contracts-utils/contracts/Nibble.sol";
+import "@darwinia/contracts-utils/contracts/Node.sol";
+
+/**
+ * @dev Verification of compact proofs for Modified Merkle-Patricia tries.
+ */
+contract CompactMerkleProof {
+    using Bytes for bytes;
+    using Keccak for bytes;
+    using Input for Input.Data;
+
+    uint8 internal constant NODEKIND_NOEXT_LEAF = 1;
+    uint8 internal constant NODEKIND_NOEXT_BRANCH_NOVALUE = 2;
+    uint8 internal constant NODEKIND_NOEXT_BRANCH_WITHVALUE = 3;
+
+    struct StackEntry {
+        bytes prefix; // The prefix is the nibble path to the node in the trie.
+        uint8 kind; // The type of the trie node.
+        bytes key; // The partail key of the trie node.
+        bytes value; // The value associated with this trie node.
+        Node.NodeHandle[16] children; // The child references to use in reconstructing the trie nodes.
+        uint8 childIndex; // The child index is in [0, NIBBLE_LENGTH],
+        bool isInline; // The trie node data less 32-byte is an isline node
+    }
+
+    struct ProofIter {
+        bytes[] proof;
+        uint256 offset;
+    }
+
+    struct ItemsIter {
+        Item[] items;
+        uint256 offset;
+    }
+
+    struct Item {
+        bytes key;
+        bytes value;
+    }
+
+    enum ValueMatch {MatchesLeaf, MatchesBranch, NotOmitted, NotFound, IsChild}
+
+    enum Step {Descend, UnwindStack}
+
+	/**
+     * @dev Returns true if `keys ans values` can be proved to be a part of a Merkle tree
+     * defined by `root`. For this, a `proof` must be provided, is a sequence of the subset 
+     * of nodes in the trie traversed while performing lookups on all keys. The trie nodes 
+     * are listed in pre-order traversal order with some values and internal hashes omitted.
+     */
+    function verify(
+        bytes32 root,
+        bytes[] memory proof,
+        bytes[] memory keys,
+        bytes[] memory values
+    ) public pure returns (bool) {
+        require(proof.length > 0, "no proof");
+        require(keys.length > 0, "no keys");
+        require(keys.length == values.length, "invalid pair");
+        Item[] memory items = new Item[](keys.length);
+        for (uint256 i = 0; i < keys.length; i++) {
+            items[i] = Item({key: keys[i], value: values[i]});
+        }
+        return verify_proof(root, proof, items);
+    }
+
+    function verify_proof(
+        bytes32 root,
+        bytes[] memory proof,
+        Item[] memory items
+    ) internal pure returns (bool) {
+        require(proof.length > 0, "no proof");
+        require(items.length > 0, "no item");
+        //TODO:: OPT
+        uint256 maxDepth = proof.length;
+        StackEntry[] memory stack = new StackEntry[](maxDepth);
+        uint256 stackLen = 0;
+        bytes memory rootNode = proof[0];
+        StackEntry memory lastEntry = decodeNode(rootNode, hex"", false);
+        ProofIter memory proofIter = ProofIter({proof: proof, offset: 1});
+        ItemsIter memory itemsIter = ItemsIter({items: items, offset: 0});
+        while (true) {
+            Step step;
+            bytes memory childPrefix;
+            (step, childPrefix) = advanceItem(lastEntry, itemsIter);
+            if (step == Step.Descend) {
+                StackEntry memory nextEntry = advanceChildIndex(
+                    lastEntry,
+                    childPrefix,
+                    proofIter
+                );
+                stack[stackLen] = lastEntry;
+                stackLen++;
+                lastEntry = nextEntry;
+            } else if (step == Step.UnwindStack) {
+                bytes memory childRef;
+                {
+                    bool isInline = lastEntry.isInline;
+                    bytes memory nodeData = encodeNode(lastEntry);
+                    if (isInline) {
+                        require(
+                            nodeData.length <= 32,
+                            "invalid child reference"
+                        );
+                        childRef = nodeData;
+                    } else {
+                        childRef = Memory.toBytes(nodeData.hash());
+                    }
+                }
+                {
+                    if (stackLen > 0) {
+                        lastEntry = stack[stackLen - 1];
+                        stackLen--;
+                        lastEntry.children[lastEntry.childIndex]
+                            .data = childRef;
+                    } else {
+                        require(
+                            proofIter.offset == proofIter.proof.length,
+                            "exraneous proof"
+                        );
+                        require(
+                            childRef.length == 32,
+                            "root hash length should be 32"
+                        );
+                        bytes32 computedRoot = abi.decode(childRef, (bytes32));
+                        if (computedRoot != root) {
+                            return false;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    function advanceChildIndex(
+        StackEntry memory entry,
+        bytes memory childPrefix,
+        ProofIter memory proofIter
+    ) internal pure returns (StackEntry memory) {
+        if (
+            entry.kind == NODEKIND_NOEXT_BRANCH_NOVALUE ||
+            entry.kind == NODEKIND_NOEXT_BRANCH_WITHVALUE
+        ) {
+            require(childPrefix.length > 0, "this is a branch");
+            entry.childIndex = uint8(childPrefix[childPrefix.length - 1]);
+            Node.NodeHandle memory child = entry.children[entry.childIndex];
+            return makeChildEntry(proofIter, child, childPrefix);
+        } else {
+            revert("cannot have children");
+        }
+    }
+
+    function makeChildEntry(
+        ProofIter memory proofIter,
+        Node.NodeHandle memory child,
+        bytes memory prefix
+    ) internal pure returns (StackEntry memory) {
+        if (child.isInline) {
+            if (child.data.length == 0) {
+                require(
+                    proofIter.offset < proofIter.proof.length,
+                    "incomplete proof"
+                );
+                bytes memory nodeData = proofIter.proof[proofIter.offset];
+                proofIter.offset++;
+                return decodeNode(nodeData, prefix, false);
+            } else {
+                return decodeNode(child.data, prefix, true);
+            }
+        } else {
+            require(child.data.length == 32, "invalid child reference");
+            revert("extraneous hash reference");
+        }
+    }
+
+    function advanceItem(StackEntry memory entry, ItemsIter memory itemsIter)
+        internal
+        pure
+        returns (Step, bytes memory childPrefix)
+    {
+        while (itemsIter.offset < itemsIter.items.length) {
+            Item memory item = itemsIter.items[itemsIter.offset];
+            bytes memory k = Nibble.keyToNibbles(item.key);
+            bytes memory v = item.value;
+            if (startsWith(k, entry.prefix)) {
+                ValueMatch vm;
+                (vm, childPrefix) = matchKeyToNode(
+                    k,
+                    entry.prefix.length,
+                    entry
+                );
+                if (ValueMatch.MatchesLeaf == vm) {
+                    if (v.length == 0) {
+                        revert("value mismatch");
+                    }
+                    entry.value = v;
+                } else if (ValueMatch.MatchesBranch == vm) {
+                    entry.value = v;
+                } else if (ValueMatch.NotFound == vm) {
+                    if (v.length > 0) {
+                        revert("value mismatch");
+                    }
+                } else if (ValueMatch.NotOmitted == vm) {
+                    revert("extraneouts value");
+                } else if (ValueMatch.IsChild == vm) {
+                    return (Step.Descend, childPrefix);
+                }
+                itemsIter.offset++;
+                continue;
+            }
+            return (Step.UnwindStack, childPrefix);
+        }
+        return (Step.UnwindStack, childPrefix);
+    }
+
+    function matchKeyToNode(
+        bytes memory k,
+        uint256 prefixLen,
+        StackEntry memory entry
+    ) internal pure returns (ValueMatch vm, bytes memory childPrefix) {
+        uint256 prefixPlufPartialLen = prefixLen + entry.key.length;
+        if (entry.kind == NODEKIND_NOEXT_LEAF) {
+            if (
+                contains(k, entry.key, prefixLen) &&
+                k.length == prefixPlufPartialLen
+            ) {
+                if (entry.value.length == 0) {
+                    return (ValueMatch.MatchesLeaf, childPrefix);
+                } else {
+                    return (ValueMatch.NotOmitted, childPrefix);
+                }
+            } else {
+                return (ValueMatch.NotFound, childPrefix);
+            }
+        } else if (
+            entry.kind == NODEKIND_NOEXT_BRANCH_NOVALUE ||
+            entry.kind == NODEKIND_NOEXT_BRANCH_WITHVALUE
+        ) {
+            if (contains(k, entry.key, prefixLen)) {
+                if (prefixPlufPartialLen == k.length) {
+                    if (entry.value.length == 0) {
+                        return (ValueMatch.MatchesBranch, childPrefix);
+                    } else {
+                        return (ValueMatch.NotOmitted, childPrefix);
+                    }
+                } else {
+                    uint8 index = uint8(k[prefixPlufPartialLen]);
+                    if (entry.children[index].exist) {
+                        childPrefix = k.substr(0, prefixPlufPartialLen + 1);
+                        return (ValueMatch.IsChild, childPrefix);
+                    } else {
+                        return (ValueMatch.NotFound, childPrefix);
+                    }
+                }
+            } else {
+                return (ValueMatch.NotFound, childPrefix);
+            }
+        } else {
+            revert("not support node type");
+        }
+    }
+
+    function contains(
+        bytes memory a,
+        bytes memory b,
+        uint256 offset
+    ) internal pure returns (bool) {
+        if (a.length < b.length + offset) {
+            return false;
+        }
+        for (uint256 i = 0; i < b.length; i++) {
+            if (a[i + offset] != b[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    function startsWith(bytes memory a, bytes memory b)
+        internal
+        pure
+        returns (bool)
+    {
+        if (a.length < b.length) {
+            return false;
+        }
+        for (uint256 i = 0; i < b.length; i++) {
+            if (a[i] != b[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @dev Encode a Node.
+     *      encoding has the following format:
+     *      NodeHeader | Extra partial key length | Partial Key | Value
+     * @param entry The stackEntry.
+     * @return The encoded branch.
+     */
+    function encodeNode(StackEntry memory entry)
+        internal
+        pure 
+        returns (bytes memory)
+    {
+        if (entry.kind == NODEKIND_NOEXT_LEAF) {
+            Node.Leaf memory l = Node.Leaf({
+                key: entry.key,
+                value: entry.value
+            });
+            return Node.encodeLeaf(l);
+        } else if (
+            entry.kind == NODEKIND_NOEXT_BRANCH_NOVALUE ||
+            entry.kind == NODEKIND_NOEXT_BRANCH_WITHVALUE
+        ) {
+            Node.Branch memory b = Node.Branch({
+                key: entry.key,
+                value: entry.value,
+                children: entry.children
+            });
+            return Node.encodeBranch(b);
+        } else {
+            revert("not support node kind");
+        }
+    }
+
+    /**
+     * @dev Decode a Node.
+     *      encoding has the following format:
+     *      NodeHeader | Extra partial key length | Partial Key | Value
+     * @param nodeData The encoded trie node data.
+     * @param prefix The nibble path to the node.
+     * @param isInline The node is an in-line node or not.
+     * @return entry The StackEntry.
+     */
+    function decodeNode(
+        bytes memory nodeData,
+        bytes memory prefix,
+        bool isInline
+    ) internal pure returns (StackEntry memory entry) {
+        Input.Data memory data = Input.from(nodeData);
+        uint8 header = data.decodeU8();
+        uint8 kind = header >> 6;
+        if (kind == NODEKIND_NOEXT_LEAF) {
+            //Leaf
+            Node.Leaf memory leaf = Node.decodeLeaf(data, header);
+            entry.key = leaf.key;
+            entry.value = leaf.value;
+            entry.kind = kind;
+            entry.prefix = prefix;
+            entry.isInline = isInline;
+        } else if (
+            kind == NODEKIND_NOEXT_BRANCH_NOVALUE ||
+            kind == NODEKIND_NOEXT_BRANCH_WITHVALUE
+        ) {
+            //BRANCH_WITHOUT_MASK_NO_EXT  BRANCH_WITH_MASK_NO_EXT
+            Node.Branch memory branch = Node.decodeBranch(data, header);
+            entry.key = branch.key;
+            entry.value = branch.value;
+            entry.kind = kind;
+            entry.children = branch.children;
+            entry.childIndex = 0;
+            entry.prefix = prefix;
+            entry.isInline = isInline;
+        } else {
+            revert("not support node kind");
+        }
+    }
+}

--- a/contracts/verify/contracts/CompactMerkleProof.t.sol
+++ b/contracts/verify/contracts/CompactMerkleProof.t.sol
@@ -1,0 +1,131 @@
+pragma solidity >=0.6.0 <0.7.0;
+
+import "@darwinia/contracts-utils/contracts/ds-test/test.sol";
+import "./CompactMerkleProof.sol";
+pragma experimental ABIEncoderV2;
+
+contract CompactMerkleProofTest is CompactMerkleProof, DSTest {
+    function setUp() public {}
+
+    function testFail_basic_sanity() public {
+        assertTrue(false);
+    }
+
+    function test_basic_sanity() public {
+        assertTrue(true);
+    }
+
+    function testSimplePairVerifyProof() public returns (bool) {
+        bytes32 root = hex"36d59226dcf98198b07207ee154ebea246a687d8c11191f35b475e7a63f9e5b4";
+        bytes[] memory proof = new bytes[](1);
+        proof[0] = hex"44646f00";
+        bytes[] memory keys = new bytes[](1);
+        keys[0] = hex"646f";
+        bytes[] memory values = new bytes[](1);
+        values[0] = hex"76657262";
+        bool res = verify(root, proof, keys, values);
+        assertTrue(res);
+		return res;
+    }
+
+    function testPairVerifyProof() public returns (bool) {
+        bytes32 root = hex"e24f300814d2ddbb2a6ba465cdc2d31004aee7741d0a4964b879f25053b2ed48";
+        bytes[] memory merkleProof = new bytes[](3);
+        merkleProof[0] = hex"c4646f4000107665726200";
+        merkleProof[1] = hex"c107400014707570707900";
+        merkleProof[2] = hex"410500";
+
+        bytes[] memory keys = new bytes[](1);
+        keys[0] = hex"646f6765";
+        bytes[] memory values = new bytes[](1);
+        values[0] = hex"0000000000000000000000000000000000000000000000000000000000000000";
+        bool res = verify(root, merkleProof, keys, values);
+        assertTrue(res);
+		return res;
+    }
+
+    function testPairsVerifyProofBlake2b() public returns (bool) {
+		bytes32 root = hex"8b5b6ad240751b4af62bf0e939731564bfb41b9bfbe01e32e00154eae31cfe43";
+        bytes[] memory merkleProof = new bytes[](1);
+        merkleProof[0] = hex"810006000c420200144203080405";
+
+        bytes[] memory keys = new bytes[](1);
+        keys[0] = hex"0102";
+        bytes[] memory values = new bytes[](1);
+        values[0] = hex"01";
+        bool res = verify(root, merkleProof, keys, values);
+        assertTrue(res);
+		return res;
+    }
+
+    function testPairsVerifyProof() public returns (bool) {
+        bytes32 root = hex"493825321d9ad0c473bbf85e1a08c742b4a0b75414f890745368b8953b873017";
+        bytes[] memory merkleProof = new bytes[](5);
+        merkleProof[0] = hex"810616010018487261766f00007c8306f7240030447365207374616c6c696f6e30447365206275696c64696e67";
+        merkleProof[1] = hex"466c6661800000000000000000000000000000000000000000000000000000000000000000";
+        merkleProof[2] = hex"826f400000";
+        merkleProof[3] = hex"8107400000";
+        merkleProof[4] = hex"410500";
+
+        //sort keys!
+        bytes[] memory keys = new bytes[](8);
+        keys[0] = hex"616c6661626574";
+        keys[1] = hex"627261766f";
+        keys[2] = hex"64";
+        keys[3] = hex"646f";
+        keys[4] = hex"646f10";
+        keys[5] = hex"646f67";
+        keys[6] = hex"646f6765";
+        keys[7] = hex"68616c70";
+
+        bytes[] memory values = new bytes[](8);
+        values[0] = hex"";
+        values[1] = hex"627261766f";
+        values[2] = hex"";
+        values[3] = hex"76657262";
+        values[4] = hex"";
+        values[5] = hex"7075707079";
+        values[6] = hex"0000000000000000000000000000000000000000000000000000000000000000";
+        values[7] = hex"";
+        bool res = verify(root, merkleProof, keys, values);
+        assertTrue(res);
+		return res;
+    }
+
+    function test_decode_leaf() public {
+        bytes memory proof = hex"410500";
+        Input.Data memory data = Input.from(proof);
+        uint8 header = data.decodeU8();
+        Node.Leaf memory l = Node.decodeLeaf(data, header);
+        assertEq0(l.key, hex"05");
+        assertEq0(l.value, hex"");
+    }
+
+    function test_encode_leaf() public {
+        bytes memory proof = hex"410500";
+        Input.Data memory data = Input.from(proof);
+        uint8 header = data.decodeU8();
+        Node.Leaf memory l = Node.decodeLeaf(data, header);
+        bytes memory b = Node.encodeLeaf(l);
+        assertEq0(proof, b);
+    }
+
+    function test_decode_branch() public {
+		bytes memory proof = hex"c10740001470757070798083809f19c0b956a97fc0175e6717d289bb0f890a67a953eb0874f89244314b34";
+        Input.Data memory data = Input.from(proof);
+        uint8 header = data.decodeU8();
+        Node.Branch memory b = Node.decodeBranch(data, header);
+        assertEq0(b.key, hex"07");
+        assertEq0(b.value, hex"7075707079");
+        //TODO:: test children
+    }
+
+    function test_encode_branch() public {
+		bytes memory proof  = hex"c10740001470757070798083809f19c0b956a97fc0175e6717d289bb0f890a67a953eb0874f89244314b34";
+        Input.Data memory data = Input.from(proof);
+        uint8 header = data.decodeU8();
+        Node.Branch memory b = Node.decodeBranch(data, header);
+        bytes memory x = Node.encodeBranch(b);
+        assertEq0(proof, x);
+    }
+}

--- a/contracts/verify/contracts/MerkleProof.sol
+++ b/contracts/verify/contracts/MerkleProof.sol
@@ -10,7 +10,7 @@ library MerkleProof {
      * @param leaf the leaf which needs to be proven
      * @param pos the position of the leaf, index starting with 0
      * @param width the width or number of leaves in the tree
-     * @param proof the array of proofs to help verify the leafs membership, ordered from leaf to root
+     * @param proof the array of proofs to help verify the leaf's membership, ordered from leaf to root
      * @return a boolean value representing the success or failure of the operation
      */
     function verifyMerkleLeafAtPosition(

--- a/contracts/verify/contracts/MerkleProof.sol
+++ b/contracts/verify/contracts/MerkleProof.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.6.0;
+
+library MerkleProof {
+    /**
+     * @notice Verify that a specific leaf element is part of the Merkle Tree at a specific position in the tree
+     *
+     * @param root the root of the merkle tree
+     * @param leaf the leaf which needs to be proven
+     * @param pos the position of the leaf, index starting with 0
+     * @param width the width or number of leaves in the tree
+     * @param proof the array of proofs to help verify the leafs membership, ordered from leaf to root
+     * @return a boolean value representing the success or failure of the operation
+     */
+    function verifyMerkleLeafAtPosition(
+        bytes32 root,
+        bytes32 leaf,
+        uint256 pos,
+        uint256 width,
+        bytes32[] memory proof
+    ) internal pure returns (bool) {
+        bytes32 computedHash = leaf;
+
+        if (pos + 1 > width) {
+            return false;
+        }
+
+        uint256 i = 0;
+        for (uint256 height = 0; width > 1; height++) {
+            bool computedHashLeft = pos % 2 == 0;
+
+            // check if at rightmost branch and whether the computedHash is left
+            if (pos + 1 == width && computedHashLeft) {
+                // there is no sibling and also no element in proofs, so we just go up one layer in the tree
+                pos /= 2;
+                width = ((width - 1) / 2) + 1;
+                continue;
+            }
+
+            if (i >= proof.length) {
+                // need another element from the proof we don't have
+                return false;
+            }
+
+            bytes32 proofElement = proof[i];
+
+            if (computedHashLeft) {
+                computedHash = keccak256(
+                    abi.encodePacked(computedHash, proofElement)
+                );
+            } else {
+                computedHash = keccak256(
+                    abi.encodePacked(proofElement, computedHash)
+                );
+            }
+
+            pos /= 2;
+            width = ((width - 1) / 2) + 1;
+            i++;
+        }
+
+        return computedHash == root;
+    }
+}


### PR DESCRIPTION
### The interactive protocol:
1. Imports:
  - `MerkleMountRangeRootHash`
  - `CurrentBlockHash`
  - MerkleRoot of PublicKeys of the next Authority Set
  - Bit-vec of validators that signed (only accept if there is enough signatures)
  - Merkle root of all signatures
2. Starts interactive verification process
  - Pick ⅓ validators that signed at random
  - Request their signatures
3. Required signatures are then submitted:
  - We get ⅓ signatures + merkle proof that all of them were part of the initial set
  - We get ⅓ public keys (or their hashes) + merkle proof that they are part of the current
    Authority Set (stored in the contract)
  - We `ecrecover` the signatures and make sure the public keys match the ones we got and the merkle
    proof is valid.

### Verification
1. Relay chain use a [Base-16 Modified Merkle Tree (trie)](https://github.com/paritytech/polkadot/blob/67da7718a87f990a2b3337ae860169116bb0e487/runtime/common/src/mmr.rs#L183) to save `beefy_next_authority_set` and `parachain_heads`, In this case, we could use `CompactMerkleProof.sol` to verify proofs.
2. [polkadot-ethereum ](https://github.com/Snowfork/polkadot-ethereum/blob/30e40ae74061a036049adb06f8a5e3c2317bfae9/relayer/workers/beefyrelayer/store/beefy.go#L97)use a [parse merkle tree](https://github.com/wealdtech/go-merkletree) to verify the proofs, In this case, we could use `MerkleProof.sol` to verify the proofs.

As I see, the `parse merkle tree` can be simpler to verify proofs by solidity according to the Implement.

### BEEFY relay protocol
An in-memory database is used for managing the 2-phase BEEFY commitment relay protocol. State transitions:

1.  BEEFY commitment is witnessed by the Substrate listener and passed to the Ethereum writer.
2. The Ethereum writer sends an `InitialVerificationTransaction` to the `LightClientBridge`. An Item is created in database containing the BEEFY commitment's information, status `InitialVerificationTxSent`, and the recently sent tx's hash.
3. Ethereum listener witnesses an `InitialVerificationSuccessful` event on the `LightClientBridge`. Fetches the relevant item from database by the event's tx hash, then updates the item with status `InitialVerificationTxConfirmed` and `CloseOnBlock`.
4. Every block, the Ethereum listener checks each commitment with status `InitialVerificationTxConfirmed` and if its `CloseOnBlock` is >= the current Ethereum block then the database item is updated with status `ReadyToComplete` and a `RandomSeed` pulled from the intended completion block's hash.
5. Ethereum writer fetches the commitment from the database and uses the `RandomSeed` to select some validator addresses/proofs then sends a `CompleteVerificationTransaction` to the `LightClientBridge`. The item is updated in database with status `CompleteVerificationTxSent`.

An [example](https://github.com/Snowfork/polkadot-ethereum/tree/main/relayer/workers/beefyrelayer) for reference