### PR TITLE
update subgraph for s2s

### DIFF
--- a/contracts/mapping-token/deploy.js
+++ b/contracts/mapping-token/deploy.js
@@ -30,11 +30,11 @@ const deployContract = async function () {
     web3.eth.accounts.wallet.add(key);
     const _1e8 = web3.utils.toHex("0x52b7d2dcc80cd2e4000000");
 
-    const abi_proxy_admin = "./artifacts/@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol/ProxyAdmin.json";
+    const abi_proxy_admin = "./artifacts/@zeppelin-solidity-4.4.0/contracts/proxy/transparent/ProxyAdmin.sol/ProxyAdmin.json";
     const abi_erc_20 = "./artifacts/contracts/darwinia/MappingERC20.sol/MappingERC20.json";
     const abi_e2d_mapping_token_factory = "./artifacts/contracts/darwinia/Ethereum2DarwiniaMappingTokenFactory.sol/Ethereum2DarwiniaMappingTokenFactory.json";
     const abi_s2s_mapping_token_factory = "./artifacts/contracts/darwinia/Sub2SubMappingTokenFactory.sol/Sub2SubMappingTokenFactory.json";
-    const abi_proxy = "./artifacts/@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol/TransparentUpgradeableProxy.json";
+    const abi_proxy = "./artifacts/@zeppelin-solidity-4.4.0/contracts/proxy/transparent/TransparentUpgradeableProxy.sol/TransparentUpgradeableProxy.json";
 
     // 1. proxy admin
     console.log("1. start to deploy proxy admin");

--- a/packages/subgraph/Sub2SubMappingTokenFactory/abis/Sub2SubMappingTokenFactory.json
+++ b/packages/subgraph/Sub2SubMappingTokenFactory/abis/Sub2SubMappingTokenFactory.json
@@ -4,9 +4,15 @@
     "inputs": [
       {
         "indexed": false,
-        "internalType": "bytes",
-        "name": "message_id",
-        "type": "bytes"
+        "internalType": "bytes4",
+        "name": "laneid",
+        "type": "bytes4"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "nonce",
+        "type": "uint64"
       },
       {
         "indexed": false,
@@ -85,9 +91,15 @@
     "inputs": [
       {
         "indexed": false,
-        "internalType": "bytes",
-        "name": "message_id",
-        "type": "bytes"
+        "internalType": "bytes4",
+        "name": "laneid",
+        "type": "bytes4"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "nonce",
+        "type": "uint64"
       },
       {
         "indexed": false,
@@ -179,9 +191,15 @@
     "inputs": [
       {
         "indexed": false,
-        "internalType": "bytes",
-        "name": "message_id",
-        "type": "bytes"
+        "internalType": "bytes4",
+        "name": "laneid",
+        "type": "bytes4"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "nonce",
+        "type": "uint64"
       },
       {
         "indexed": false,
@@ -210,6 +228,13 @@
     ],
     "name": "RemoteUnlockConfirmed",
     "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DEAD_ADDRESS",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
   },
   {
     "inputs": [],
@@ -253,13 +278,6 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "admin",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
     "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "name": "allMappingTokens",
     "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
@@ -300,7 +318,8 @@
   },
   {
     "inputs": [
-      { "internalType": "bytes", "name": "messageId", "type": "bytes" },
+      { "internalType": "bytes4", "name": "laneid", "type": "bytes4" },
+      { "internalType": "uint64", "name": "nonce", "type": "uint64" },
       { "internalType": "bool", "name": "result", "type": "bool" }
     ],
     "name": "confirmBurnAndRemoteUnlock",
@@ -363,7 +382,7 @@
   },
   {
     "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
-    "name": "mappingToken2Info",
+    "name": "mappingToken2OriginalInfo",
     "outputs": [
       { "internalType": "uint32", "name": "tokenType", "type": "uint32" },
       {
@@ -426,15 +445,6 @@
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "_admin", "type": "address" }
-    ],
-    "name": "setAdmin",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
       { "internalType": "address", "name": "mapping_token", "type": "address" },
       { "internalType": "uint256", "name": "amount", "type": "uint256" }
     ],
@@ -492,6 +502,16 @@
   },
   {
     "inputs": [
+      { "internalType": "address", "name": "mapping_token", "type": "address" },
+      { "internalType": "address", "name": "new_owner", "type": "address" }
+    ],
+    "name": "transferMappingTokenOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
       { "internalType": "address", "name": "newOwner", "type": "address" }
     ],
     "name": "transferOwnership",
@@ -522,7 +542,11 @@
         "name": "original_token",
         "type": "address"
       },
-      { "internalType": "address", "name": "mapping_token", "type": "address" },
+      {
+        "internalType": "address",
+        "name": "new_mapping_token",
+        "type": "address"
+      },
       { "internalType": "uint256", "name": "index", "type": "uint256" }
     ],
     "name": "updateMappingToken",

--- a/packages/subgraph/Sub2SubMappingTokenFactory/schema.graphql
+++ b/packages/subgraph/Sub2SubMappingTokenFactory/schema.graphql
@@ -1,6 +1,7 @@
 type BurnRecordEntity @entity {
   id: ID!
-  message_id: Bytes! # bytes
+  lane_id: Bytes! # bytes
+  nonce: BigInt!
   request_transaction: Bytes! # bytes
   response_transaction: Bytes # bytes
   sender: Bytes! # address
@@ -14,7 +15,8 @@ type BurnRecordEntity @entity {
 
 type LockRecordEntity @entity {
   id: ID!
-  message_id: Bytes!
+  lane_id: Bytes!
+  nonce: BigInt!
   mapping_token: Bytes!
   recipient: Bytes!
   amount: BigInt!

--- a/packages/subgraph/Sub2SubMappingTokenFactory/src/mapping.ts
+++ b/packages/subgraph/Sub2SubMappingTokenFactory/src/mapping.ts
@@ -18,16 +18,18 @@ export function handleBurnAndWaitingConfirm(
 ): void {
   // Entities can be loaded from the store using a string ID; this ID
   // needs to be unique across all entities of the same type
-  let entity = BurnRecordEntity.load(event.params.message_id.toHexString())
+  let message_id = event.params.laneid.toHexString() + event.params.nonce.toHexString()
+  let entity = BurnRecordEntity.load(message_id)
 
   // Entities only exist after they have been saved to the store;
   // `null` checks allow to create entities on demand
   if (entity == null) {
-    entity = new BurnRecordEntity(event.params.message_id.toHexString())
+    entity = new BurnRecordEntity(message_id)
   }
 
   // Entity fields can be set based on event parameters
-  entity.message_id = event.params.message_id
+  entity.lane_id = event.params.laneid
+  entity.nonce = event.params.nonce
   entity.sender = event.params.sender
   entity.recipient = event.params.recipient
   entity.token = event.params.token
@@ -81,11 +83,13 @@ export function handleDailyLimitChange(event: DailyLimitChange): void {}
 export function handleIssuingERC20Created(event: IssuingERC20Created): void {}
 
 export function handleIssuingMappingToken(event: IssuingMappingToken): void {
-    let entity = LockRecordEntity.load(event.transaction.hash.toHexString())
+    let message_id = event.params.laneid.toHexString() + event.params.nonce.toHexString()
+    let entity = LockRecordEntity.load(message_id)
     if (entity == null) {
-        entity = new LockRecordEntity(event.transaction.hash.toHexString())
+        entity = new LockRecordEntity(message_id)
     }
-    entity.message_id = event.params.message_id
+    entity.lane_id = event.params.laneid
+    entity.nonce = event.params.nonce
     entity.mapping_token = event.params.mapping_token
     entity.recipient = event.params.recipient
     entity.amount = event.params.amount
@@ -102,12 +106,13 @@ export function handleOwnershipTransferred(event: OwnershipTransferred): void {}
 export function handleRemoteUnlockConfirmed(
   event: RemoteUnlockConfirmed
 ): void {
-  let entity = new BurnRecordEntity(event.params.message_id.toHexString())
-  if (entity == null) {
-    return
-  }
-  entity.result = event.params.result ? 1 : 2
-  entity.response_transaction = event.transaction.hash
-  entity.end_timestamp = event.block.timestamp
-  entity.save()
+    let message_id = event.params.laneid.toHexString() + event.params.nonce.toHexString()
+    let entity = new BurnRecordEntity(message_id)
+    if (entity == null) {
+        return
+    }
+    entity.result = event.params.result ? 1 : 2
+    entity.response_transaction = event.transaction.hash
+    entity.end_timestamp = event.block.timestamp
+    entity.save()
 }

--- a/packages/subgraph/Sub2SubMappingTokenFactory/subgraph.yaml
+++ b/packages/subgraph/Sub2SubMappingTokenFactory/subgraph.yaml
@@ -6,10 +6,8 @@ dataSources:
     name: Sub2SubMappingTokenFactory
     network: pangolin
     source:
-      #address: "0xCB48D99a252c0536109385982f4770d96115DCa2"
-      address: "0x61dc46385a09e7ed7688abe6f66bf3d8653618fd"
+      address: "0x92496871560a01551E1B4fD04540D7A519D5C19e"
       abi: Sub2SubMappingTokenFactory
-      startBlock: 1378573
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -27,13 +25,13 @@ dataSources:
         - name: Sub2SubMappingTokenFactory
           file: ./abis/Sub2SubMappingTokenFactory.json
       eventHandlers:
-        - event: BurnAndWaitingConfirm(bytes,address,bytes,address,uint256)
+        - event: BurnAndWaitingConfirm(bytes4,uint64,address,bytes,address,uint256)
           handler: handleBurnAndWaitingConfirm
         - event: DailyLimitChange(address,uint256)
           handler: handleDailyLimitChange
         - event: IssuingERC20Created(address,address,address)
           handler: handleIssuingERC20Created
-        - event: IssuingMappingToken(bytes,address,address,uint256)
+        - event: IssuingMappingToken(bytes4,uint64,address,address,uint256)
           handler: handleIssuingMappingToken
         - event: MappingTokenUpdated(bytes32,address,address)
           handler: handleMappingTokenUpdated
@@ -41,6 +39,6 @@ dataSources:
           handler: handleNewLogicSetted
         - event: OwnershipTransferred(indexed address,indexed address)
           handler: handleOwnershipTransferred
-        - event: RemoteUnlockConfirmed(bytes,address,address,uint256,bool)
+        - event: RemoteUnlockConfirmed(bytes4,uint64,address,address,uint256,bool)
           handler: handleRemoteUnlockConfirmed
       file: ./src/mapping.ts


### PR DESCRIPTION
event params `message_id`(bytes=encodePacked(lane_id, nonce)) to `lane_id`(bytes4) and `nonce`(u64)
latest test result
```
{
  "data": {
    "burnRecordEntities": [
      {
        "amount": "10001",
        "end_timestamp": "1637739042",
        "id": "0x726f6c690x1",
        "lane_id": "0x726f6c69",
        "nonce": "1",
        "request_transaction": "0xc9c6d2d643932691e7d17fc56065ff69e98543ec4f2f0db76384ec690e4b184b",
        "response_transaction": "0x559dc082af86c9821ce362e1220d48029649a5e55411787b8bb8a3df0bd59333",
        "result": 1,
        "sender": "0x6be02d1d3665660d22ff9624b7be0551ee1ac91b",
        "start_timestamp": "1637738988"
      }
    ]
  }
}
```